### PR TITLE
Clippy-ify the project, introduce FiniteBuffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "arbitrary"
-version = "0.2.0-pre"
-authors = ["Simonas Kazlauskas <arbitrary@kazlauskas.me>"]
+version = "0.2.0"
+authors = ["Simonas Kazlauskas <arbitrary@kazlauskas.me>", "Brian L. Troutwine <brian@troutwine.us>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/nagisa/rust_arbitrary/"
 documentation = "https://docs.rs/arbitrary/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbitrary"
-version = "0.1.1"
+version = "0.2.0-pre"
 authors = ["Simonas Kazlauskas <arbitrary@kazlauskas.me>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/nagisa/rust_arbitrary/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,21 +7,7 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![deny(unused)]
-#![cfg_attr(feature = "cargo-clippy", deny(clippy))]
-// #![cfg_attr(feature = "cargo-clippy", deny(clippy_pedantic))]
-#![cfg_attr(feature = "cargo-clippy", deny(clippy_perf))]
-#![cfg_attr(feature = "cargo-clippy", deny(clippy_style))]
-#![cfg_attr(feature = "cargo-clippy", deny(clippy_complexity))]
-#![cfg_attr(feature = "cargo-clippy", deny(clippy_correctness))]
-#![cfg_attr(feature = "cargo-clippy", deny(clippy_cargo))]
-// We allow 'cast_possible_wrap' and 'cast_possible_truncation' as we'll use the
-// Arbitrary definitions of u8 et al to generate the signed variants and in so
-// doing trip the cast warning.
-#![cfg_attr(feature = "cargo-clippy", allow(cast_possible_wrap))]
-#![cfg_attr(feature = "cargo-clippy", allow(cast_possible_truncation))]
-// We allow 'implicit_hasher' since support for a generalized hasher will
-// require setting a 'static lifetime. Tricky, that.
-#![cfg_attr(feature = "cargo-clippy", allow(implicit_hasher))]
+
 use std::borrow::{Cow, ToOwned};
 use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
-//! TODO(blt)
+//! The Arbitrary trait crate
+//!
+//! This trait provides an `Arbitrary` trait to produce well-typed data from
+//! byte buffers. The crate additionally provides different flavors of byte
+//! buffers with useful semantics.
 #![deny(warnings)]
 #![deny(bad_style)]
 #![deny(missing_docs)]
@@ -23,7 +27,7 @@ use std::time::Duration;
 ///
 /// This could be a random number generator, a static ring buffer of bytes or some such.
 pub trait Unstructured {
-    /// TODO(blt)
+    /// The error type for [`Unstructured`], see implementations for details
     type Error;
     /// Fill a `buffer` with bytes, forming the unstructured data from which
     /// `Arbitrary` structured data shall be generated.
@@ -39,7 +43,8 @@ pub trait Unstructured {
     }
 }
 
-/// TODO(blt)
+/// A trait to generate and shrink arbitrary types from an [`Unstructured`] pool
+/// of bytes.
 pub trait Arbitrary: Sized + 'static {
     /// Generate arbitrary structured data from unstructured data.
     fn arbitrary<U: Unstructured + ?Sized>(u: &mut U) -> Result<Self, U::Error>;
@@ -527,7 +532,7 @@ pub struct RingBuffer<'a> {
 }
 
 impl<'a> RingBuffer<'a> {
-    /// TODO(blt)
+    /// Create a new RingBuffer
     pub fn new(buffer: &'a [u8], max_len: usize) -> Result<Self, BufferError> {
         if buffer.is_empty() {
             return Err(BufferError::EmptyInput);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@ use std::time::Duration;
 pub trait Unstructured {
     /// TODO(blt)
     type Error;
-    /// Fill a `buffer` with bytes, forming the unstructured data from which `Arbitrary` structured
-    /// data shall be generated.
+    /// Fill a `buffer` with bytes, forming the unstructured data from which
+    /// `Arbitrary` structured data shall be generated.
     ///
     /// This operation is fallible to allow implementations based on e.g. I/O.
     fn fill_buffer(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error>;
@@ -465,25 +465,90 @@ impl<A: Arbitrary> Arbitrary for ::std::num::Wrapping<A> {
     }
 }
 
+/// An enumeration of buffer creation errors
+#[derive(Debug, Clone, Copy)]
+pub enum BufferError {
+    /// The input buffer is empty, causing construction of some buffer types to
+    /// fail
+    EmptyInput,
+}
+
+/// A source of unstructured data with a finite size
+///
+/// This buffer is a finite source of unstructured data. Once the data is
+/// exhausted it stays exhausted.
+pub struct FiniteBuffer<'a> {
+    buffer: &'a [u8],
+    offset: usize,
+    max_len: usize,
+}
+
+impl<'a> FiniteBuffer<'a> {
+    /// Create a new FiniteBuffer
+    ///
+    /// If the passed `buffer` is shorter than max_len the total number of bytes
+    /// will be the bytes available in `buffer`. If `buffer` is longer than
+    /// `max_len` the buffer will be trimmed.
+    pub fn new(buffer: &'a [u8], max_len: usize) -> Result<Self, BufferError> {
+        let buf: &'a [u8] = if buffer.len() > max_len {
+            &buffer[..max_len]
+        } else {
+            // This branch is hit if buffer is shorter than max_len. We might
+            // choose to make this an error condition instead of, potentially,
+            // surprising folks with less bytes.
+            buffer
+        };
+
+        Ok(FiniteBuffer {
+            buffer: buf,
+            offset: 0,
+            max_len: buf.len(),
+        })
+    }
+}
+
+impl<'a> Unstructured for FiniteBuffer<'a> {
+    type Error = ();
+
+    fn fill_buffer(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        if (self.max_len - self.offset) >= buffer.len() {
+            let max = self.offset + buffer.len();
+            for (i, idx) in (self.offset..max).enumerate() {
+                buffer[i] = self.buffer[idx];
+            }
+            self.offset = max;
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    // NOTE(blt) I'm not sure if this is the right definition. I don't
+    // understand the purpose of container_size.
+    fn container_size(&mut self) -> Result<usize, Self::Error> {
+        <usize as Arbitrary>::arbitrary(self).map(|x| x % self.max_len)
+    }
+}
+
 /// A source of unstructured data which returns the same data over and over again
 ///
-/// A simplest provider of unstructured data possible. Interprets the data as a ring buffer,
-/// thus allowing for infinite amount of not-very-random data.
+/// This buffer acts as a ring buffer over the source of unstructured data,
+/// allowing for an infinite amount of not-very-random data.
 pub struct RingBuffer<'a> {
     buffer: &'a [u8],
-    off: usize,
+    offset: usize,
     max_len: usize,
 }
 
 impl<'a> RingBuffer<'a> {
     /// TODO(blt)
-    pub fn new(buffer: &'a [u8], max_len: usize) -> Result<RingBuffer<'a>, &'static str> {
+    pub fn new(buffer: &'a [u8], max_len: usize) -> Result<Self, BufferError> {
         if buffer.is_empty() {
-            return Err("buffer must not be empty");
+            return Err(BufferError::EmptyInput);
         }
         Ok(RingBuffer {
             buffer,
-            off: 0,
+            offset: 0,
             max_len,
         })
     }
@@ -492,9 +557,9 @@ impl<'a> RingBuffer<'a> {
 impl<'a> Unstructured for RingBuffer<'a> {
     type Error = ();
     fn fill_buffer(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        let b = [&self.buffer[self.off..], &self.buffer[..self.off]];
+        let b = [&self.buffer[self.offset..], &self.buffer[..self.offset]];
         let it = ::std::iter::repeat(&b[..]).flat_map(|x| x).flat_map(|&x| x);
-        self.off = (self.off + buffer.len()) % self.buffer.len();
+        self.offset = (self.offset + buffer.len()) % self.buffer.len();
         for (d, f) in buffer.iter_mut().zip(it) {
             *d = *f;
         }
@@ -508,7 +573,19 @@ impl<'a> Unstructured for RingBuffer<'a> {
 
 #[cfg(test)]
 mod test {
-    use super::{RingBuffer, Unstructured};
+    use super::*;
+
+    #[test]
+    fn finite_buffer_fill_buffer() {
+        let x = [1, 2, 3, 4];
+        let mut rb = FiniteBuffer::new(&x, 10).unwrap();
+        let mut z = [0; 2];
+        rb.fill_buffer(&mut z).unwrap();
+        assert_eq!(z, [1, 2]);
+        rb.fill_buffer(&mut z).unwrap();
+        assert_eq!(z, [3, 4]);
+        assert!(rb.fill_buffer(&mut z).is_err());
+    }
 
     #[test]
     fn ring_buffer_fill_buffer() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,11 +506,14 @@ impl<'a> Unstructured for RingBuffer<'a> {
     }
 }
 
+#[cfg(test)]
 mod test {
+    use super::{RingBuffer, Unstructured};
+
     #[test]
     fn ring_buffer_fill_buffer() {
         let x = [1, 2, 3, 4];
-        let mut rb = RingBuffer::new(&x, 2);
+        let mut rb = RingBuffer::new(&x, 2).unwrap();
         let mut z = [0; 10];
         rb.fill_buffer(&mut z).unwrap();
         assert_eq!(z, [1, 2, 3, 4, 1, 2, 3, 4, 1, 2]);
@@ -521,7 +524,7 @@ mod test {
     #[test]
     fn ring_buffer_container_size() {
         let x = [1, 2, 3, 4, 5];
-        let mut rb = RingBuffer::new(&x, 11);
+        let mut rb = RingBuffer::new(&x, 11).unwrap();
         assert_eq!(rb.container_size().unwrap(), 9);
         assert_eq!(rb.container_size().unwrap(), 1);
         assert_eq!(rb.container_size().unwrap(), 2);


### PR DESCRIPTION
Hello! I've been using rust_arbitrary in my [bughunt](https://github.com/blt/bughunt-rust) project and this PR is an omnibus of the work I've done to the project. I have: 

* introduced tougher clippy lints to the project in 23b6cc5, quieted them
* placed the test module inside of a `#[cfg(test)]` in bb37731
* introduced `FiniteBuffer` in ad2f546
* remove agressive clippy lints for want of stable `tool_lints` feature in 7148fb7 

The `FiniteBuffer` operates similarly to `RingBuffer` excepting that it is a finite pool of bytes to draw from, contrasted to ring's infinite pool. 

This PR has some TODO comments remaining in it. I'm opening this PR to gauge in omnibus form to gauge your interest in the separate bits of work and in the hope that you'll not mind taking these things all in one big shot. :) If you are interested in any of the bits of work but don't want them in an omnibus I'd be happy to split this PR into smaller bites. If you're cool with the omnibus approach I'll correct the TODOs in this PR. 